### PR TITLE
Fix Remnote2Obsidian script breaking with blank rem objects

### DIFF
--- a/Remnote2Obsidian/Remnote2Obsidian.py
+++ b/Remnote2Obsidian/Remnote2Obsidian.py
@@ -1,6 +1,7 @@
 # terminal code: "cd Remnote2Obsidian && python Remnote2Obsidian.py"
 
 # print("Python execution started")
+from collections.abc import Mapping
 import sys, os, json, datetime, re
 
 # Import modules from current project:
@@ -64,14 +65,22 @@ for x in RemnoteDocs:
 
 def getAllDocs(RemList):
     IDlist = []
+
     for rem in RemList:
+        # Skip blank rem links
+        if not isinstance(rem, Mapping):
+            continue
+
         if rem.get("forceIsFolder", False):
             childRem = []
             for child in rem["children"]:
-                dict = [x for x in RemnoteDocs if x["_id"] == child][0] 
-                childRem.append(dict)
+                dict_search = [x for x in RemnoteDocs if x["_id"] == child]
+                
+                if dict_search:
+                    dict = [0] 
+                    childRem.append(dict)
             IDlist.extend(getAllDocs(childRem))
-        if(len(rem["children"])>0
+        if("children" in rem and len(rem["children"])>0
         or (len(rem.get("portalsIn", []))>0)
         or (len(rem.get("references", []))>0)
         or (len(rem.get("typeChildren", []))>0)):


### PR DESCRIPTION
Hey there! I want to thank you for making such a great Remnote-to-Obsidian converter, it certainly saved me a few headaches when moving my notes over. It seems the original script ends up breaking whenever there are untitled blank rem objects in the `rem.json` output, as it assumes every object in the list is a dictionary. When I checked the JSON, the untitled blank rems are instead in the following array format:
```json
[0]
```

As these rems are completely empty there really isn't a need for them to be imported over, so I went ahead and added a check to the `getAllDocs` function to ignore any non-dict objects.